### PR TITLE
nodejs 10 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,17 +2,9 @@ var util = require('util'),
     fs = require('fs'),
     stream = require('stream'),
     Writable = stream.Writable,
-    constants = process.binding('constants');
+    constants = fs.constants;
 
-if (constants.fs) {
-    // nodejs-6 divide constants into logical groups,
-    // we're interested in `fs` constants only
-    constants = constants.fs;
-}
-
-// pray for kernels gods to work, if node version <0.10.29,
-// which does not includes the commit http://git.io/mW15lA
-var O_NONBLOCK = constants.O_NONBLOCK || 04000,
+var O_NONBLOCK = constants.O_NONBLOCK ,
     S_IFIFO = constants.S_IFIFO,
     O_WRONLY = constants.O_WRONLY;
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ util.inherits(WriteStream, Writable);
 function isFIFOWritable(path) {
     try {
         var fd = fs.openSync(path, O_WRONLY | O_NONBLOCK, S_IFIFO);
-        fs.close(fd);
+        fs.closeSync(fd);
     } catch(e) {
         return false;
     }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
       "type": "MIT",
       "url": "http://github.com/nodules/fifo-stream/raw/master/LICENSE"
     }
-  ]
+  ],
+  "engine": {
+    "node": ">=6.3"
+  }
 }


### PR DESCRIPTION
1)  Use fs.constants without hacks `constants = process.binding('constants');` -> `constants = fs.constants;`
2) `fs.close` -> `fs.closeSync`. nodejs 10 throws error for async function without callbacks